### PR TITLE
Replace removed File.exists? with File.exist? for Ruby 3.2.0 compatibility

### DIFF
--- a/lib/cloudinary/helper.rb
+++ b/lib/cloudinary/helper.rb
@@ -179,7 +179,7 @@ module CloudinaryHelper
     version_store = options.delete(:version_store)
     if options[:version].blank? && (version_store == :file) && defined?(Rails) && defined?(Rails.root)
       file_name = "#{Rails.root}/tmp/cloudinary/cloudinary_sprite_#{source.sub(/\..*/, '')}.version"
-      if File.exists?(file_name)
+      if File.exist?(file_name)
         options[:version] = File.read(file_name).chomp
       end
     end


### PR DESCRIPTION
### Brief Summary of Changes

This update replaces the deprecated and removed `File.exists?` method with `File.exist?` to ensure compatibility with Ruby 3.2.0 and later versions, where the old method has been entirely removed.

https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [ ] Yes
- [x] No

#### Reviewer, please note:

I am not sure the function `cl_sprite_url` is still in use.

#### Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I ran the full test suite before pushing the changes and all the tests pass.
